### PR TITLE
add more detailed instructions to get started in the Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,16 +64,14 @@ You'll need Python 3, virtualenv and sqlite3:
 
  1. Set up virtualenv
  2. activate the virtualenv
-    - `virtualenv .`
-    - `source bin/activate`
+    - `virtualenv venv`
+    - `source venv/bin/activate`
  3. Install packages from `requirements.txt`
     - `pip install -r requirements.txt`
  4. Configure app by copying and optionally editing `.env-example` to `.env`.
     - `cp  .env-example .env`
  5. Run the database migrations
     - `python ./manage.py migrate`
- 6. Create the static files (also, run this command every time you change anything in the static folders)
-    - `python manage.py collectstatic --noinput`
  7. Start the server
     - `python manage.py runserver 0.0.0.0:8000`
  8. Develop!

--- a/README.md
+++ b/README.md
@@ -63,10 +63,20 @@ to download the results.
 You'll need Python 3, virtualenv and sqlite3:
 
  1. Set up virtualenv
- 2. Install packages from `requirements.txt`
- 3. Configure app by copying and optionally editing `.env-example` to `.env`.
- 4. Develop!
-
+ 2. activate the virtualenv
+    - `virtualenv .`
+    - `source bin/activate`
+ 3. Install packages from `requirements.txt`
+    - `pip install -r requirements.txt`
+ 4. Configure app by copying and optionally editing `.env-example` to `.env`.
+    - `cp  .env-example .env`
+ 5. Run the database migrations
+    - `python ./manage.py migrate`
+ 6. Create the static files (also, run this command every time you change anything in the static folders)
+    - `python manage.py collectstatic --noinput`
+ 7. Start the server
+    - `python manage.py runserver 0.0.0.0:8000`
+ 8. Develop!
 
 Alternatively, you can use [Docker](http://docker.com/):
 

--- a/README.md
+++ b/README.md
@@ -72,9 +72,9 @@ You'll need Python 3, virtualenv and sqlite3:
     - `cp  .env-example .env`
  5. Run the database migrations
     - `python ./manage.py migrate`
- 7. Start the server
+ 6. Start the server
     - `python manage.py runserver 0.0.0.0:8000`
- 8. Develop!
+ 7. Develop!
 
 Alternatively, you can use [Docker](http://docker.com/):
 


### PR DESCRIPTION
@bwinton @jtg567 @rayborn
As someone who generally does not develop in nor use Python I was rather lost when trying to figure out the instructions to get the app started. I've added some more details to the `Application Development` section of the readme to make this easier for the next person.

I may have done the virtual environment part incorrectly, so if you have any advice there I'd appreciate it. It works for me, but it sets up the `virtualenv`directly in the same directory as the project, which may not be best. 

~~Important Note: `.env-example` is needed, and does not exist in this repo. I did not add it as I'm not sure what keys it should contain. When I was running locally I had to improvise my own .env file.~~

removed the .env-example as @jtg567 added one